### PR TITLE
refactor/rename probs to roicat_

### DIFF
--- a/code/classification.py
+++ b/code/classification.py
@@ -397,14 +397,20 @@ if __name__ == "__main__":
         )
 
         # save results
+        # Datasets are named with a `roicat_` prefix to make their
+        # provenance (the ROICaT classifier) explicit and to avoid
+        # collision with other per-ROI probabilities (e.g. the
+        # extraction cellpose_soma_probability). These names match the
+        # NWB roi_table column names written downstream.
         with h5py.File(plane.output_classification_file, "w") as f:
-            g = f.create_group("soma")
-            g.create_dataset("predictions", data=soma_predictions)
-            g.create_dataset("probabilities", data=soma_probabilities)
-
-            g = f.create_group("dendrites")
-            g.create_dataset("predictions", data=dendrite_predictions)
-            g.create_dataset("probabilities", data=dendrite_probabilities)
+            f.create_dataset("roicat_is_soma", data=soma_predictions)
+            f.create_dataset(
+                "roicat_soma_probability", data=soma_probabilities
+            )
+            f.create_dataset("roicat_is_dendrite", data=dendrite_predictions)
+            f.create_dataset(
+                "roicat_dendrite_probability", data=dendrite_probabilities
+            )
 
             g = f.create_group("border")
             g.create_dataset("labels", data=border_rois)

--- a/code/classification.py
+++ b/code/classification.py
@@ -397,18 +397,22 @@ if __name__ == "__main__":
         )
 
         # save results
-        # Datasets are named with a `roicat_` prefix to make their
-        # provenance (the ROICaT classifier) explicit and to avoid
-        # collision with other per-ROI probabilities (e.g. the
-        # extraction cellpose_soma_probability). These names match the
-        # NWB roi_table column names written downstream.
+        # Outputs keep their per-cell-type groups (`soma`, `dendrites`),
+        # with fully-qualified `roicat_*` dataset names inside so their
+        # provenance (the ROICaT classifier) is explicit and they map
+        # directly to the flat `roicat_*` NWB roi_table columns written
+        # downstream (avoiding collision with the extraction
+        # `rois/cellpose_soma_probability`).
         with h5py.File(plane.output_classification_file, "w") as f:
-            f.create_dataset("roicat_is_soma", data=soma_predictions)
-            f.create_dataset(
+            g = f.create_group("soma")
+            g.create_dataset("roicat_is_soma", data=soma_predictions)
+            g.create_dataset(
                 "roicat_soma_probability", data=soma_probabilities
             )
-            f.create_dataset("roicat_is_dendrite", data=dendrite_predictions)
-            f.create_dataset(
+
+            g = f.create_group("dendrites")
+            g.create_dataset("roicat_is_dendrite", data=dendrite_predictions)
+            g.create_dataset(
                 "roicat_dendrite_probability", data=dendrite_probabilities
             )
 

--- a/code/classification.py
+++ b/code/classification.py
@@ -398,22 +398,25 @@ if __name__ == "__main__":
 
         # save results
         # Outputs keep their per-cell-type groups (`soma`, `dendrites`),
-        # with fully-qualified `roicat_*` dataset names inside so their
-        # provenance (the ROICaT classifier) is explicit and they map
-        # directly to the flat `roicat_*` NWB roi_table columns written
-        # downstream (avoiding collision with the extraction
+        # mirroring the pre-existing `predictions`/`probabilities`
+        # dataset names with a `roicat_` prefix to make their provenance
+        # (the ROICaT classifier) explicit. The group + dataset map to
+        # flat `roicat_soma_*` / `roicat_dendrite_*` NWB roi_table
+        # columns downstream (avoiding collision with the extraction
         # `rois/cellpose_soma_probability`).
         with h5py.File(plane.output_classification_file, "w") as f:
             g = f.create_group("soma")
-            g.create_dataset("roicat_is_soma", data=soma_predictions)
+            g.create_dataset("roicat_predictions", data=soma_predictions)
             g.create_dataset(
-                "roicat_soma_probability", data=soma_probabilities
+                "roicat_probabilities", data=soma_probabilities
             )
 
             g = f.create_group("dendrites")
-            g.create_dataset("roicat_is_dendrite", data=dendrite_predictions)
             g.create_dataset(
-                "roicat_dendrite_probability", data=dendrite_probabilities
+                "roicat_predictions", data=dendrite_predictions
+            )
+            g.create_dataset(
+                "roicat_probabilities", data=dendrite_probabilities
             )
 
             g = f.create_group("border")


### PR DESCRIPTION
As part of addressing https://github.com/AllenNeuralDynamics/aind-ophys-nwb/issues/76

Rename the soma and dendrite probabilities in the classifier_h5 to specifically mention the modal roicat_.

This distinguishes them from the new cellpose_soma_probability in the extraction.h5, and will be reflected in a related change to aind-ophys-nwb